### PR TITLE
[Fix]計画達成確認メソッド修正、実績作成バッチ処理修正

### DIFF
--- a/app/helpers/homes_helper.rb
+++ b/app/helpers/homes_helper.rb
@@ -56,8 +56,8 @@ module HomesHelper
   # プランを達成していたら表示する
   def plan_clear(verb)
     plan_allot = verb.plan_allots.first
-    plan_allot_time = plan_allot.allot_h * 3600 + plan_allot.allot_m * 60
-    real_allot_time = recording_time_set(verb)
+    return unless plan_allot_time = plan_allot.allot_h * 3600 + plan_allot.allot_m * 60
+    return unless real_allot_time = recording_time_set(verb)
     if plan_allot_time < real_allot_time
       tag.i(class: 'fas fa-check fa-3x check_achieve_after') +
         (tag.p '(目標達成！)')

--- a/lib/tasks/achieve_record.rake
+++ b/lib/tasks/achieve_record.rake
@@ -10,7 +10,7 @@ namespace :achieve_record do
       real_allots = RealAllot.where(user_id: actioned_user.id, created_at: 1.day.ago.all_day).order(:verb_id)
       real_allots.each do |real_allot|
         # real_allotのレコードの分だけ達成記録としてレコードを作成する
-        AchieveRecord.create!(user_id: real_allot.user_id, verb_name: real_allot.verb.name, allot: real_allot.allot)
+        AchieveRecord.create!(user_id: real_allot.user_id, verb_name: real_allot.verb.name, allot: real_allot.allot, created_at: 1.day.ago)
       end
     end
   end


### PR DESCRIPTION
・計画や実際の行動が無い場合に対応
・実績作成時の日付を昨日に指定して、日付誤差をなくす。