### PR TITLE
[Update]現在の実行時間をヘルパーメソッドから独立して表示

### DIFF
--- a/app/helpers/homes_helper.rb
+++ b/app/helpers/homes_helper.rb
@@ -1,31 +1,38 @@
 module HomesHelper
+  # 現在の実行時間を返すメソッド
+  def current_execution_time(verb)
+    case DetailRealAllot.find_by(verb_id: verb.id, end_time: nil).blank?
+      # 計測停止中の場合
+    when true
+      # real_allotがまだ無い、もしくは値がnilのときに実行
+      if recording_time_set(verb).blank?
+        tag.p('現在の実行時間　00:00:00')
+      # それ以外はreal_allotの値を表示する
+      else
+        tag.p('現在の実行時間　' + Time.at(recording_time_set(verb)).utc.strftime('%X'))
+      end
+      # 計測実行中の場合
+    when false
+      (tag.input id: 'record-time', type: 'hidden', value: recording_time_set(verb)) +
+        (tag.p id: 'record_time_output')
+      end
+  end
+
   # 優先アクションの実行時間のスタート/ストップのリンクの切り替え
   def prioritize_action_record_toggle(verb)
     case DetailRealAllot.find_by(verb_id: verb.id, end_time: nil).blank?
     # 計測停止中の場合
     when true
-      # real_allotがまだ無い、もしくは値がnilのときに実行
-      if recording_time_set(verb).blank?
-        tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'prioritize-action__doswitch-body') do |tag|
-          tag.div(class: 'prioritize-action__doswitch-body-a') +
-            tag.div(class: 'prioritize-action__doswitch-body-b')
-        end +
-          tag.p('現在の実行時間　00:00:00')
-      # それ以外はreal_allotの値を表示する
-      else
-        tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'prioritize-action__doswitch-body') do |tag|
-          tag.div(class: 'prioritize-action__doswitch-body-a') +
-            tag.div(class: 'prioritize-action__doswitch-body-b')
-        end +
-          tag.p('現在の実行時間　' + Time.at(recording_time_set(verb)).utc.strftime('%X'))
+      tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'prioritize-action__doswitch-body') do |tag|
+        tag.div(class: 'prioritize-action__doswitch-body-a') +
+          tag.div(class: 'prioritize-action__doswitch-body-b')
       end
     # 計測実行中の場合
     when false
       tag.a('', href: record_stop_path(user_id: current_user.id, id: verb.id), class: 'prioritize-action__doswitch-body is-switch-active') do |tag|
         tag.div(class: 'prioritize-action__doswitch-body-a') +
           tag.div(class: 'prioritize-action__doswitch-body-b')
-      end +
-        (tag.p id: 'record_time_output')
+      end
     end
   end
 
@@ -34,28 +41,16 @@ module HomesHelper
     case DetailRealAllot.find_by(verb_id: verb.id, end_time: nil).blank?
     # 計測停止中の場合
     when true
-      # real_allotがまだ無い、もしくは値がnilのときに実行
-      if recording_time_set(verb).blank?
-        tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'setup-action__doswitch-body') do |tag|
-          tag.div(class: 'setup-action__doswitch-body-a') +
-            tag.div(class: 'setup-action__doswitch-body-b')
-        end +
-          tag.p('現在の実行時間　00:00:00')
-      # それ以外はreal_allotの値を表示する
-      else
-        tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'setup-action__doswitch-body') do |tag|
-          tag.div(class: 'setup-action__doswitch-body-a') +
-            tag.div(class: 'setup-action__doswitch-body-b')
-        end +
-          tag.p('現在の実行時間　' + Time.at(recording_time_set(verb)).utc.strftime('%X'))
+      tag.a('', href: record_start_path(user_id: current_user.id, id: verb.id), class: 'setup-action__doswitch-body') do |tag|
+        tag.div(class: 'setup-action__doswitch-body-a') +
+          tag.div(class: 'setup-action__doswitch-body-b')
       end
     # 計測実行中の場合
     when false
       tag.a('', href: record_stop_path(user_id: current_user.id, id: verb.id), class: 'setup-action__doswitch-body is-switch-active') do |tag|
         tag.div(class: 'setup-action__doswitch-body-a') +
           tag.div(class: 'setup-action__doswitch-body-b')
-      end +
-        (tag.p id: 'record_time_output')
+      end
     end
   end
 

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -1,34 +1,35 @@
 <body class="top-page">
   <section class="top-page__section">
-  <div class="top-page__main-title">
-    <h2 class="top-page__title">
-    <span>D</span>ooo<span>S</span>witch
-    </h2>
-    <p class="top-page__app-discription">〜行動計測アプリ〜</p>
+    <div class="top-page__main-title">
+      <h2 class="top-page__title">
+        <span>D</span>ooo<span>S</span>witch
+      </h2>
+      <p class="top-page__app-discription">〜行動計測アプリ〜</p>
     </div>
     <div class="prioritize-action">
       <h3 class="prioritize-action__title">
         【最優先アクション】
       </h3>
       <div class="prioritize-action__list">
-      <ul class="prioritize-action__list-ul">
-      <% @important_verbs.each do |verb| %>
-      <li class="prioritize-action__item">
-        <p class="prioritize-action__actName">
-          <%= verb.name %>
-        </p>
-          <div class="prioritize-action__doswitch">
-            <div class="prioritize-action__doswitchStandTop">
-              <%= prioritize_action_record_toggle(verb) %>
-            </div>
-            <div class="prioritize-action__doswitchStandBody">
-            </div>
-          </div>
-        <%= plan_time(verb) %>
-        <%= plan_clear(verb) %>
-        </li>
-      <% end %>
-      </ul>
+        <ul class="prioritize-action__list-ul">
+          <% @important_verbs.each do |verb| %>
+            <li class="prioritize-action__item">
+              <p class="prioritize-action__actName">
+                <%= verb.name %>
+              </p>
+              <%= current_execution_time(verb) %>
+              <%= plan_time(verb) %>
+              <%= plan_clear(verb) %>
+              <div class="prioritize-action__doswitch">
+                <div class="prioritize-action__doswitchStandTop">
+                  <%= prioritize_action_record_toggle(verb) %>
+                </div>
+                <div class="prioritize-action__doswitchStandBody">
+                </div>
+              </div>
+            </li>
+          <% end %>
+        </ul>
       </div>
     </div>
     <div class="setup-action">
@@ -39,21 +40,24 @@
       <div class="setup-action__list">
         <ul class="setup-action__list-ul">
           <% @selected_verbs.each do |verb| %>
-          <li class="setup-action__item">
-            <p class="setup-action__actName">
-              <%= verb.name %>
-            </p>
-            <div class="setup-action__doswitch">
-              <div class="setup-action__doswitchStandTop">
-                <%= setup_action_record_toggle(verb) %>
+            <li class="setup-action__item">
+              <p class="setup-action__actName">
+                <%= verb.name %>
+              </p>
+              <%= current_execution_time(verb) %>
+              <%= plan_time(verb) %>
+              <%= plan_clear(verb) %>
+              <div class="setup-action__doswitch">
+                <div class="setup-action__doswitchStandTop">
+                  <%= setup_action_record_toggle(verb) %>
+                </div>
+                <div class="setup-action__doswitchStandBody">
+                </div>
               </div>
-              <div class="setup-action__doswitchStandBody">
-              </div>
-            </div>
-            <%# setup_action_record_toggle(verb) %>
-            <%= plan_time(verb) %>
-          </li>
+            </li>
           <% end %>
+        </ul>
       </div>
+    </div>
   </section>
 </body>


### PR DESCRIPTION
ヘルパーメソッド内にスイッチを表すタグと実行時間を表すタグを共存させるとスイッチを押したときの挙動に応じて実行時間も不要に動いてしまうため
・ヘルパーメソッドから実行時間を分離
・実行時間表示メソッド(current_execution_time)を設定

・ヘルパー内の重複コードリファクタリング
・一部トップページのインデント、タグの囲い方修正