### PR TITLE
Top layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,5 +25,6 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  color: #696969;
   font-family: "Rounded M+";
 }

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -6,8 +6,8 @@
 .top-page{
 
     &__main-title{
-        margin: 80px 0 100px;
-        font-size: 100px;
+        margin-top: 20px;
+        font-size: 80px;
     }
 
     &__title{
@@ -22,17 +22,34 @@
             font-family: "自家製Rounded M+";
         }
     }
+
+    &__furigana-do{
+        font-size: 0.3em;
+        color: #6495ed;
+        position: absolute;
+            left: 18em;
+    }
+
+    &__furigana-switch{
+        font-size: 0.3em;
+        color: #6495ed;
+        position: absolute;
+            right: 16.5em;
+    }
+
     &__app-discription{
         position:　absolute;
         margin-top: -0.5em;
+        color: #696969;
         font-size: 0.25em;
         text-align: center;
     }
 }
 
-
 .prioritize-action,
 .setup-action {
+
+    text-align: center;
 
     &::after{
         display: block;
@@ -41,16 +58,19 @@
     }
 
     &__title{
+        position: relative;
+        display: inline-block;
+        padding: 0.2em 0.5em;
+        border-radius: 2em;
         font-family: "Rounded M+";
         text-align: center;
-        padding-left: 25px;
+        border: dashed 2px white;
     }
 
     &__actName {
-        margin-bottom: 80px;
+        margin-bottom: 4em;
         text-align: center;
     }
-
 
     &__doswitch{
         position: relative;
@@ -58,23 +78,21 @@
 
     &__doswitchStandTop {
         /* スイッチ台座部分 */
+        position: relative;
         width: 220px;
         height: 50px;
         margin: 0 auto;
         border-radius: 50%;
-        position: relative;
         z-index: 1;
     }
 
     &__doswitchStandBody{/* スイッチスタンド */
+        position: absolute;
         width: 220px;
         height: 120px;
         margin: 0 auto;
         border-radius: 5px 5px 50% 50% / 5px 5px 33.3% 33.3%; 
-        position: absolute;
         box-shadow: 0 3px 3px;
-
-
     }
 
     &__doswitch-body {
@@ -115,17 +133,21 @@
         top: -20px;
         background-color: #f5f5f5;
     }
-
 }
 
 .prioritize-action{
 
+    &__title{
+        background: #ffa899;
+        box-shadow: 0px 0px 0px 5px #ffa899;
+    }
+
     &__list-ul{
-        margin: 50px 0 0 70px;
+        margin: 0.5em 0 0 6em;
     }
 
     &__item {
-        margin-right: 20px;
+        margin-right: 10px;
         float: left;
         width: 45%;
         list-style: none;
@@ -144,8 +166,15 @@
 
 .setup-action{
 
+    margin: 6em 0 8em;
+
+    &__title{
+        background-color: #ffd280;
+        box-shadow: 0px 0px 0px 5px #ffd280;
+    }
+
     &__list-ul{
-        margin: 50px 0 0 80px;
+        margin: -3em 0 0 80px;
     }
 
     &__item {
@@ -167,12 +196,6 @@
 }
 
 
-
-
-.prioritize-action{
-    margin-bottom: 150px;
-}
-
 .is-switch-active {
     /* 選択時スイッチ */
     height: 22px;
@@ -189,7 +212,6 @@
     /* 選択時スイッチ */
     background-color: #ff0000
 }
-
 
 .btn_area {
     width: 200px;

--- a/app/views/homes/top.html.erb
+++ b/app/views/homes/top.html.erb
@@ -2,6 +2,8 @@
   <section class="top-page__section">
   <div class="top-page__main-title">
     <h2 class="top-page__title">
+    <p class="top-page__furigana-do"> ドゥ</p>
+    <p class="top-page__furigana-switch"> スイッチ</p>
     <span>D</span>ooo<span>S</span>witch
     </h2>
     <p class="top-page__app-discription">〜行動計測アプリ〜</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,11 @@
   </head>
 
   <body>
+        <div class="container">
+        
+        <%= yield %>
         <main>
-      <div class="container">
+
         <% if user_signed_in? %>
           link
           <%= link_to "トップ", root_path, class: "btn btn-default" %>
@@ -25,7 +28,6 @@
         <div id="flash_messages">
           <%= render "layouts/flash_messages" %>
         </div>
-        <%= yield %>
       </div>
     </main>
   </body>


### PR DESCRIPTION
[トップページ]
・アプリタイトルロゴに振り仮名「ドゥスイッチ」を加えました
・最優先アクション、設定アクションの見出しのレイアウト作成
・ご要望の１ページにまとめるやつやりました。css調整しました。
　ヘッダーは画面上にないけど一番下に一時的に移動させてます。下にスクロールすると出てくると思う（application.scss.erb一時的に変更。ヘッダー作ったら元に戻します。▶︎左横にナビを作ろうかなと思ってます）

