### PR TITLE
[Add]bootstrap4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.1'
 gem 'bootsnap', '>= 1.1.0', require: false
 # BootstrapでSassを使うgem
-gem 'bootstrap-sass', '~> 3.4.1'
+gem 'bootstrap', '4.0.0'
 gem 'jbuilder', '~> 2.5'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.4', '>= 5.2.4.1'
@@ -26,7 +26,8 @@ gem 'jquery-rails'
 # Railsで定時処理をするためのgem
 gem 'whenever', require: false
 # JavaScriptのランタイムを用意
-gem 'therubyracer', platforms: :ruby
+# gem 'therubyracer', platforms: :ruby
+gem 'mini_racer', '~> 0.2.4'
 gem 'chartkick'
 # カレンダー表示するためのgem
 gem 'fullcalendar-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,9 +61,10 @@ GEM
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
+    bootstrap (4.0.0)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.32.2)
@@ -113,7 +114,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    libv8 (3.16.14.19)
+    libv8 (7.3.492.27.1-x86_64-linux)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -132,6 +133,8 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.14)
+      libv8 (> 7.3)
     minitest (5.14.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -149,6 +152,7 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     pluginator (1.5.0)
+    popper_js (1.16.0)
     pre-commit (0.39.0)
       pluginator (~> 1.5)
     pry (0.13.1)
@@ -192,7 +196,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    ref (2.0.0)
     refile-mini_magick (0.2.0)
       mini_magick (~> 4.0)
       refile (~> 0.5)
@@ -253,8 +256,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.3.0)
-      ffi (~> 1.9)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -275,9 +276,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -313,7 +311,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
-  bootstrap-sass (~> 3.4.1)
+  bootstrap (= 4.0.0)
   byebug
   capybara (>= 2.15)
   chartkick
@@ -323,6 +321,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.2)
+  mini_racer (~> 0.2.4)
   momentjs-rails
   paranoia
   pre-commit
@@ -340,7 +339,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
-  therubyracer
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
  *= require_self
  *= require fullcalendar
 */
-@import "bootstrap-sprockets";
+
 @import "bootstrap";
 
 //アプリタイトル題名


### PR DESCRIPTION
bootstrap3を消してbootstrap4を試しに導入しました。
トップページのレイアウトが少し崩れてます。
別ブランチでレイアウト修正してプッシュするね。

[Gemfile,Gemfile.lock]
＜9行目について＞
gem 'bootstrap', '4.0.0'の導入

＜29行目、30行目について＞
bootstrap4導入により、
gem 'therubyracer', platforms: :rubyをgem 'mini_racer', '~> 0.2.4'に変更
変更前のgemは一応消さずにコメントアウトしてます。
これにしないとbootstrap4が動かなくって・・・(ToT)
もし何か他の機能に影響あればそっち優先するのでご相談ください！
※調べたけどgem therubyracerは難点もちょいちょいあるから廃れてるみたい？
参考▶︎https://note.com/konpyu/n/na213a14ad1e3
　　　https://qiita.com/jkr_2255/items/1d4cf636e044c0093091

（ExecJS::RubyRacerRuntime is not supported. Please replace therubyracer with mini_racer in your Gemfile or use Node.js as ExecJS runtime.エラーが出たので）
https://teratail.com/questions/156341
↑これをみて変更

[application.scss]
bootstrap4導入により
＠import "bootstrap-sprockets";
不要のため削除。